### PR TITLE
[FEAT] 아이템 장바구니 추가 기능 구현

### DIFF
--- a/src/main/java/dosopt/server/eqlserver/api/cart/CartController.java
+++ b/src/main/java/dosopt/server/eqlserver/api/cart/CartController.java
@@ -1,8 +1,14 @@
 package dosopt.server.eqlserver.api.cart;
 
+import dosopt.server.eqlserver.api.cart.dto.request.CartAddRequest;
+import dosopt.server.eqlserver.common.dto.ApiResponse;
 import dosopt.server.eqlserver.service.cart.CartQueryService;
 import dosopt.server.eqlserver.service.cart.CartService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,4 +18,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class CartController {
     private final CartService cartService;
     private final CartQueryService cartQueryService;
+
+    @PutMapping("/add")
+    public ApiResponse<?> addItemToCart(@RequestBody final CartAddRequest request, HttpServletResponse response) {
+        boolean isItemAlreadyExist = cartService.addItemToCart(request);
+
+        if (isItemAlreadyExist) {
+            response.setStatus(HttpServletResponse.SC_OK);
+            return ApiResponse.success(HttpStatus.OK, "장바구니의 상품 갯수가 정상적으로 추가되었습니다.");
+        }
+        response.setStatus(HttpServletResponse.SC_CREATED);
+        return ApiResponse.success(HttpStatus.CREATED, "상품이 장바구니에 정상적으로 추가되었습니다.");
+    }
 }

--- a/src/main/java/dosopt/server/eqlserver/api/cart/dto/request/CartAddRequest.java
+++ b/src/main/java/dosopt/server/eqlserver/api/cart/dto/request/CartAddRequest.java
@@ -1,0 +1,9 @@
+package dosopt.server.eqlserver.api.cart.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CartAddRequest {
+    private long memberId;
+    private long itemId;
+}

--- a/src/main/java/dosopt/server/eqlserver/api/item/ItemController.java
+++ b/src/main/java/dosopt/server/eqlserver/api/item/ItemController.java
@@ -6,8 +6,8 @@ import dosopt.server.eqlserver.service.item.ItemQueryService;
 import dosopt.server.eqlserver.service.item.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,7 +17,7 @@ public class ItemController {
     private final ItemService itemService;
     private final ItemQueryService itemQueryService;
 
-    @RequestMapping("/item/{itemId}")
+    @GetMapping("/item/{itemId}")
     @ResponseStatus(HttpStatus.OK)
     public ApiResponse<ItemResponse> findItemInfo(@PathVariable("itemId") final Long itemId) {
         return ApiResponse.success(HttpStatus.OK, "상품 상세 조회에 성공했습니다.", itemQueryService.findItemById(itemId));

--- a/src/main/java/dosopt/server/eqlserver/domain/Cart.java
+++ b/src/main/java/dosopt/server/eqlserver/domain/Cart.java
@@ -12,11 +12,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Table(name = "carts")
 @Entity
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Cart extends BaseEntity {
 
     @Id
@@ -34,4 +38,16 @@ public class Cart extends BaseEntity {
 
     @Column(name = "item_amount", nullable = false)
     private int amount;
+
+    public static Cart newInstance(Member member, Item item) {
+        return Cart.builder()
+                .member(member)
+                .item(item)
+                .amount(1)
+                .build();
+    }
+
+    public void addOneAmount() {
+        this.amount++;
+    }
 }

--- a/src/main/java/dosopt/server/eqlserver/repository/CartRepository.java
+++ b/src/main/java/dosopt/server/eqlserver/repository/CartRepository.java
@@ -1,7 +1,12 @@
 package dosopt.server.eqlserver.repository;
 
 import dosopt.server.eqlserver.domain.Cart;
+import dosopt.server.eqlserver.domain.Item;
+import dosopt.server.eqlserver.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CartRepository extends JpaRepository<Cart, Long> {
+
+    Optional<Cart> findByMemberAndItem(Member member, Item item);
 }

--- a/src/main/java/dosopt/server/eqlserver/service/cart/CartService.java
+++ b/src/main/java/dosopt/server/eqlserver/service/cart/CartService.java
@@ -1,6 +1,14 @@
 package dosopt.server.eqlserver.service.cart;
 
+import dosopt.server.eqlserver.api.cart.dto.request.CartAddRequest;
+import dosopt.server.eqlserver.domain.Cart;
+import dosopt.server.eqlserver.domain.Item;
+import dosopt.server.eqlserver.domain.Member;
+import dosopt.server.eqlserver.global.exception.IllegalArgumentException;
 import dosopt.server.eqlserver.repository.CartRepository;
+import dosopt.server.eqlserver.repository.ItemRepository;
+import dosopt.server.eqlserver.repository.MemberRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,4 +18,24 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class CartService {
     private final CartRepository cartRepository;
+    private final MemberRepository memberRepository;
+    private final ItemRepository itemRepository;
+
+    public boolean addItemToCart(CartAddRequest request) {
+        Member member = memberRepository.findById(request.getMemberId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("존재하지 않는 회원ID(%d) 입니다.", request.getMemberId())));
+
+        Item item = itemRepository.findById(request.getItemId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        String.format("존재하지 않는 상품ID(%d) 입니다.", request.getItemId())));
+
+        Optional<Cart> optionalCart = cartRepository.findByMemberAndItem(member, item);
+        if (optionalCart.isPresent()) {
+            optionalCart.get().addOneAmount();
+            return true;
+        }
+        cartRepository.save(Cart.newInstance(member, item));
+        return false;
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #6

## 🔑 Key Changes

1. 아이템 장바구니 추가 기능 구현
    - 해당 유저의 장바구니에 아이템이 이미 존재하면 아이템의 갯수 +1
    - 해당 유저의 장바구니에 아이템이 존재하지 않으면 Cart테이블에 아이템 추가 후 갯수 1로 설정

## 📢 To Reviewers
- 장바구니에 상품 추가하는 기능 구현했습니다

## 💻 API test
- 장바구니 처음 추가 test
![장바구니 처음 추가](https://github.com/DO-SOPT-CDS-5/EQL-server/assets/128011308/181c353c-a2b0-4e76-a9f3-8f04a9ab892c)

- 장바구니 상품 갯수 추가 test
![기존 상품 갯수 추가](https://github.com/DO-SOPT-CDS-5/EQL-server/assets/128011308/20b1b42c-5fdd-4a2c-8c98-ed346ae60494)
